### PR TITLE
img.linuxfr.org should not redirect stylesheets if redirects img (circular dep)

### DIFF
--- a/conf/nginx/sites-available/img.alpha.linuxfr.org
+++ b/conf/nginx/sites-available/img.alpha.linuxfr.org
@@ -13,7 +13,7 @@ server {
 
     add_header X-Content-Type-Options nosniff;
 
-    location ~* ^/(fonts|images|javascripts|stylesheets) {
+    location ~* ^/(fonts|images|javascripts) {
 		rewrite ^/(.*) $scheme://linuxfr.org/$1 permanent;
     }
 

--- a/conf/nginx/sites-available/img.linuxfr.org
+++ b/conf/nginx/sites-available/img.linuxfr.org
@@ -13,7 +13,7 @@ server {
 
     add_header X-Content-Type-Options nosniff;
 
-    location ~* ^/(fonts|images|javascripts|stylesheets) {
+    location ~* ^/(fonts|images|javascripts) {
 		rewrite ^/(.*) $scheme://linuxfr.org/$1 permanent;
     }
 


### PR DESCRIPTION
cf. https://linuxfr.org/suivi/rendre-accessible-les-images-des-themes-sur-img-linuxfr-org

_images_ must be redirected from http://img.linuxfr.org to http://linuxfr.org because modified _stylesheets_ are hosted by http://img.linuxfr.org and _images_ are hosted by http://img.linuxfr.org . So we must not redirect _stylesheets_ because they are already where they should be.

It’s because _stylesheets_ are not redirected that we need to redirect _images_ and other assets.
