### PR TITLE
Avoid an error when the logfile does not exist

### DIFF
--- a/scripts/postrotate-nginx
+++ b/scripts/postrotate-nginx
@@ -13,9 +13,10 @@ cd $WEBLOGS_DIR
 mkdir -p $LOG_DATE
 
 cd $WEBALIZER_INPUT
-xz access.log.1
-xz error.log.1
 
-mv access.log.1.xz ${WEBLOGS_DIR}/${LOG_DATE}/access.log.xz
-mv error.log.1.xz  ${WEBLOGS_DIR}/${LOG_DATE}/error.log.xz
-
+for logfile in access.log error.log
+do
+        if [ -f ${logfile}.1 ]; then
+                xz ${logfile}.1 && mv ${logfile}.1.xz ${WEBLOGS_DIR}/${LOG_DATE}/${logfile}.xz
+        fi
+done


### PR DESCRIPTION
Logrotate configuration does not rotate empty files.
If the rotated file does not exist, it makes xz then mv angry.
Consequences : script exits badly, and logrotate tells us about it every day.