### PR TITLE
Nginx enable cache for woff and woff2 fonts

### DIFF
--- a/conf/nginx/generator.rb
+++ b/conf/nginx/generator.rb
@@ -81,7 +81,7 @@ server {
         proxy_pass http://epub-frontend;
     }
 
-    location ~* \.(css|js|ico|gif|jpe?g|png|svg|xcf|ttf|otf|dtd)$ {
+    location ~* \.(css|js|ico|gif|jpe?g|png|svg|xcf|ttf|otf|dtd|woff2?)$ {
         expires 10d;
     }
 <% if env == "alpha" %>

--- a/conf/nginx/mime.types
+++ b/conf/nginx/mime.types
@@ -59,4 +59,5 @@ types {
     font/opentype                         otf;
     font/truetype                         ttf;
     application/font-woff                 woff;
+    font/woff2                            woff2;
 }

--- a/conf/nginx/sites-available/alpha.linuxfr.org
+++ b/conf/nginx/sites-available/alpha.linuxfr.org
@@ -50,7 +50,7 @@ server {
         proxy_pass http://epub-frontend;
     }
 
-    location ~* \.(css|js|ico|gif|jpe?g|png|svg|xcf|ttf|otf|dtd)$ {
+    location ~* \.(css|js|ico|gif|jpe?g|png|svg|xcf|ttf|otf|dtd|woff2?)$ {
         expires 10d;
     }
 

--- a/conf/nginx/sites-available/linuxfr.org
+++ b/conf/nginx/sites-available/linuxfr.org
@@ -50,7 +50,7 @@ server {
         proxy_pass http://epub-frontend;
     }
 
-    location ~* \.(css|js|ico|gif|jpe?g|png|svg|xcf|ttf|otf|dtd)$ {
+    location ~* \.(css|js|ico|gif|jpe?g|png|svg|xcf|ttf|otf|dtd|woff2?)$ {
         expires 10d;
     }
 


### PR DESCRIPTION
I've manually looked for `otf` and `ttf` font configuration.

From that search, I've manually added configuration for `woff` and `woff2` fonts.

Maybe that's not the good way to work with this repository, but it describes what should be done to fix:
https://linuxfr.org/suivi/ajouter-un-reglage-de-cache-aux-nouvelles-polices

In summary: this PR add the `woff2` mime type and enable UA caching for `woff` and `woff2`.